### PR TITLE
add:formからの送信機能

### DIFF
--- a/src/main/resources/templates/confirm.html
+++ b/src/main/resources/templates/confirm.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+<meta charset="UTF-8">
+<title>Title</title>
+</head>
+<body>
+	<span th:inline="text"> 
+		氏名：[[${user.name}]]<br>
+		E-mail：[[${user.email}]]<br>
+		年齢：[[${user.age}]]<br>	
+	</span>
+</body>
+</html>

--- a/src/main/resources/templates/form.html
+++ b/src/main/resources/templates/form.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+<meta charset="UTF-8">
+<title>Title</title>
+</head>
+
+<body>
+	<form th:action="@{/form}" th:object="${user}" method="post"> <!-- th:object：フォームにバインドするオブジェクトを設定します。 -->
+		<label for="name">氏名：</label>                           <!-- 今回は、コントローラ側で用意した“user”オブジェクトを設定しています。 -->
+		<input type="text" th:field="*{name}"><br>                <!-- *{フィールド名}は選択変数式で、th:objectが付いたタグ内では、オブジェクト名を省略できます。 -->
+                                                                  <!-- th:objectを使用しない場合、以下のように ${オブジェクト名.フィールド名}を指定する必要があります。 -->
+		<label for="email">E-mail：</label> 
+		<input type="email" th:field="*{email}"><br> 
+		
+		<label for="age">年齢：</label>
+		<input type="number" th:field="*{age}"><br>
+
+		<button>送信</button>
+	</form>
+</body>
+</html>


### PR DESCRIPTION
### th:object・・・フォームにバインドするオブジェクトを設定します。

今回は、コントローラ側で用意した“user”オブジェクトを設定しています。 
*{フィールド名}は選択変数式で、th:objectが付いたタグ内では、オブジェクト名を省略できます。
th:objectを使用しない場合、以下のように ${オブジェクト名.フィールド名}を指定する必要があります。 
```html
<input type="number" th:field="${user.age}"> 
```
---
### th:field・・・フィールドを設定します。

これは、<input>タグのid・name・value属性を、HTMLに出力する機能です。以下の２つは、同じ動きをします。 
```html
<input type="number" th:field="*{age}">
<input type="number" id="age" name="age" th:value="*{age}">
```
---
### th:value・・・th:fieldを使わない場合は、th:valueだけの使用もできます。
これはHTMLのvalue属性に、値を設定します。

---
### th:inline=“text”・・・タグ内のテキストを展開します。
[[ ]]で囲むと、その値を表示できます。

```html:src/main/resources/templates/confirm.html
<body>
  <span th:inline="text">
      氏名： [[${user.name}]]<br>
      E-Mail： [[${user.email}]]<br>
      年齢： [[${user.age}]]<br>
  </span>
</body>
```

https://gyazo.com/d008c54e556c7ba5ea47259fa37fb026